### PR TITLE
Hot Fix: Deleting sun.misc import

### DIFF
--- a/src/main/java/org/albacete/simd/experiments/ExperimentBNLauncher.java
+++ b/src/main/java/org/albacete/simd/experiments/ExperimentBNLauncher.java
@@ -6,8 +6,6 @@ import org.albacete.simd.clustering.Clustering;
 import org.albacete.simd.clustering.HierarchicalClustering;
 import org.albacete.simd.clustering.RandomClustering;
 import org.albacete.simd.framework.BNBuilder;
-import sun.misc.Signal;
-import sun.misc.SignalHandler;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;


### PR DESCRIPTION
Deleting sun.misc import because it is causing unexpected errors, and the import is not used.